### PR TITLE
Fix warning in setup.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ CHANGES
 ----------------
 
 - Add support for Python 3.5, 3.6 and 3.9.
+- Fix warning in setup.py.
 
 
 1.1 (2019-12-03)

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ directive for XML-RPC views that supports a ``layer`` parameter.""",
         'zope.location',
         'zope.principalregistry',
         'zope.securitypolicy',
-        'zope.testbrowser[zope-functional-testing]',
+        'zope.testbrowser',
         'zope.testrunner',
     ]),
 )


### PR DESCRIPTION
zope-testbrowser does not provide extra:
"zope-functional-testing"

fixes #3